### PR TITLE
Update deprecated xorg package names (Nix)

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -65,13 +65,13 @@ in
         nspr
         nss
         pango
-        xorg.libX11
-        xorg.libxcb
-        xorg.libXcomposite
-        xorg.libXdamage
-        xorg.libXext
-        xorg.libXfixes
-        xorg.libXrandr
+        libx11
+        libxcb
+        libxcomposite
+        libxdamage
+        libxext
+        libxfixes
+        libxrandr
       ];
 
     extraInstallCommands = ''


### PR DESCRIPTION
Nix gave the warning:
evaluation warning: The xorg package set has been deprecated
https://github.com/NixOS/nixpkgs/pull/479724

this renames the x11 packages to the new names.